### PR TITLE
[GITHUB-3] Adds start on boot option to php int

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ This role uses tags: **build** and **configure**
 See the [Examples](#examples) section for details on how to setup these
 integrations.
 
+### enabled and start_on_boot flags
+
+Integrations should have two flags to activate them, enabled and start_on_boot.
+
+The enabled flag covers the installation of the integration and is normally
+run via the build tag; useful for baking the integration packages
+into an image without writing any config or starting any services.
+
+The start_on_boot flag will start the integration and write any required
+config files, executed via the configure tag. This tag can be used for
+activating an integration on a per environment basis.
+
 ### PHP
 
 Installs New Relic's PHP integration and configures an INI file with symlinks
@@ -69,8 +81,9 @@ Installs New Relic's system metrics integration and configures an INI file with
 settings. Comes with default settings that setup license key, log levels and
 instance labels.
 
-By default the service for this integration is not enabled on boot, this is so
-you can start the service once an instance has finished booting. The intention
+By default the start_on_boot flag for this integration is not enabled on boot,
+in addition to allowing you to enable the service per environment you can also
+start the service elsewhere once an instance has finished booting. The intention
 here is to prevent false alerts triggered by the high saturation encountered
 during OS boot.
 
@@ -112,6 +125,7 @@ Enable PHP7 integration:
         integrations:
           php:
             enabled: true
+            start_on_boot: yes
 ```
 
 Enable PHP5 integration:
@@ -130,6 +144,7 @@ Enable PHP5 integration:
             ini_paths:
               base: /etc/php/5.0/mods-available/newrelic.ini
               links:
-                - /etc/php/5.0/fpm/conf.d/newrelic.ini
-                - /etc/php/5.0/cli/conf.d/newrelic.ini
+                - /etc/php/5.0/fpm/conf.d/20-newrelic.ini
+                - /etc/php/5.0/cli/conf.d/20-newrelic.ini
+            start_on_boot: yes
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,13 +10,14 @@ sansible_newrelic:
       ini_paths:
         base: /etc/php/7.0/mods-available/newrelic.ini
         links:
-          - /etc/php/7.0/fpm/conf.d/newrelic.ini
-          - /etc/php/7.0/cli/conf.d/newrelic.ini
+          - /etc/php/7.0/fpm/conf.d/20-newrelic.ini
+          - /etc/php/7.0/cli/conf.d/20-newrelic.ini
       ini_config: [ ]
         # - option: number_of_cats
         #   section: mammals
         #   value: 42
-      version: "7.6.*"
+      start_on_boot: no
+      version: "7.7.*"
     sysmond:
       enabled: false
       ini_config: [ ]

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -44,12 +44,14 @@
   ini_file:
     dest: "{{ sansible_newrelic.integrations.php.ini_paths.base }}"
     group: "{{ sansible_newrelic.group }}"
-    mode: 0640
+    mode: 0644
     owner: "{{ sansible_newrelic.user }}"
     section: "{{ item.section | default(None) }}"
     option: "{{ item.option }}"
     value: "{{ item.value }}"
-  when: sansible_newrelic.integrations.php.enabled
+  when:
+    - sansible_newrelic.integrations.php.enabled
+    - sansible_newrelic.integrations.php.start_on_boot
   with_items: "{{ [
         {
           'option': 'extension',
@@ -85,4 +87,6 @@
     src: "{{ sansible_newrelic.integrations.php.ini_paths.base }}"
     state: link
   with_items: "{{ sansible_newrelic.integrations.php.ini_paths.links }}"
-  when: sansible_newrelic.integrations.php.enabled
+  when:
+    - sansible_newrelic.integrations.php.enabled
+    - sansible_newrelic.integrations.php.start_on_boot

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -39,3 +39,7 @@
     pkg: "newrelic-php5={{ sansible_newrelic.integrations.php.version }}"
     state: present
   when: sansible_newrelic.integrations.php.enabled
+  with_items:
+    - "newrelic-daemon={{ sansible_newrelic.integrations.php.version }}"
+    - "newrelic-php5-common={{ sansible_newrelic.integrations.php.version }}"
+    - "newrelic-php5={{ sansible_newrelic.integrations.php.version }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -28,6 +28,7 @@
         integrations:
           php:
             enabled: true
+            start_on_boot: true
           sysmond:
             enabled: true
         labels: "org:sansible,role:newrelic"


### PR DESCRIPTION
Adds start_on_boot option to PHP integration so it can be enabled
on a per environment basis.

Fixes perms on ini file so the PHP extension can be picked up by
fpm.

Specifies all packages required for PHP integration installation
so specific versioning works properly.