### PR TITLE
[GITHUB-17] Make PHP extension configurable

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -30,6 +30,7 @@ lint:
 dependency:
   name: galaxy
   options:
+    ignore-certs: True
     role-file: requirements.yml
 
 scenario:

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 
 - src: sansible.php
-  version: v2.0
+  version: v2.0.3
 
 - src: sansible.users_and_groups
-  version: v2.0
+  version: v2.0.2

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -35,7 +35,7 @@
   with_items: "{{ [
         {
           'option': 'extension',
-          'value': '/usr/lib/php/20151012/newrelic.so'
+          'value': 'newrelic.so'
         },
         {
           'option': 'newrelic.license',


### PR DESCRIPTION
Changes the path to the `newrelic.so` PHP extension to use a relative path, which should point to the default PHP extensions dir.

Signed-off-by: Riya Dennis <riya.dennis@sainsburys.co.uk>